### PR TITLE
feat(backup): add reusable credentials component

### DIFF
--- a/clusters/main/components/backup/credentials/kustomization.yaml
+++ b/clusters/main/components/backup/credentials/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+
+replacements:
+  - source:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      fieldPath: metadata.name
+    targets:
+      - select:
+          group: helm.toolkit.fluxcd.io
+          version: v2
+          kind: HelmRelease
+        fieldPaths:
+          - spec.values.credentials.minio.bucket
+        options:
+          delimiter: "-"
+          index: 1

--- a/clusters/main/components/backup/credentials/patch.yaml
+++ b/clusters/main/components/backup/credentials/patch.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: not-used
+spec:
+  values:
+    credentials:
+      minio:
+        type: s3
+        url: "http://${S3_URL}"
+        bucket: "${S3_BUCKET}-APP"
+        accessKey: "${S3_ACCESKEY}"
+        secretKey: "${S3_SECRETKEY}"
+        encrKey: "${S3_ENCRKEY}"
+      blaze:
+        type: s3
+        url: "https://${S3_BLAZE_URL}"
+        bucket: "${S3_BLAZE_BUCKET}"
+        accessKey: "${S3_BLAZE_ACCESKEY}"
+        secretKey: "${S3_BLAZE_SECRETKEY}"
+        encrKey: "${S3_BLAZE_ENCRKEY}"

--- a/clusters/main/kubernetes/apps/speedtest-tracker/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/app/helm-release.yaml
@@ -49,22 +49,6 @@ spec:
                 DISPLAY_TIMEZONE: "Europe/Amsterdam"
                 SPEEDTEST_SERVERS: "52857"
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-speedtest-tracker"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/speedtest-tracker/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials


### PR DESCRIPTION
## Summary

Adds a reusable `backup/credentials` Kustomize component and applies it only to `speedtest-tracker`.

- shared MinIO and Blaze credential settings live in the component
- MinIO bucket suffix is derived from `HelmRelease.metadata.name`
- removes the inline `credentials` block from speedtest-tracker
- keeps VolSync and CNPG configured to use `blaze`

## Validation

Ran:

```bash
kubectl kustomize clusters/main/kubernetes/apps/speedtest-tracker/app
```

The rendered HelmRelease contains:

```yaml
credentials:
  minio:
    bucket: ${S3_BUCKET}-speedtest-tracker
```

No changes were applied to the cluster.