### PR TITLE
feat(backup): migrate apps to shared credentials component

### DIFF
--- a/clusters/main/kubernetes/apps/authelia/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/helm-release.yaml
@@ -35,22 +35,6 @@ spec:
     global:
       stopAll: false
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-authelia"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/authelia/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - referencegrant.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/bazarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-bazarr"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/bazarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/guacamole/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/app/helm-release.yaml
@@ -35,15 +35,6 @@ spec:
     global:
       stopAll: false
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-guacamole"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/guacamole/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
@@ -35,22 +35,6 @@ spec:
     global:
       stopAll: false
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-home-assistant"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/home-assistant/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}-homepage"
-        bucket: "${S3_BUCKET}-bazarr"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/homepage/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
@@ -35,22 +35,6 @@ spec:
     global:
       stopAll: false
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-immich"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/immich/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/lldap/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/lldap/app/helm-release.yaml
@@ -56,22 +56,6 @@ spec:
                 LLDAP_SMTP_OPTIONS__USER: ${SMTP_USER}
                 LLDAP_key_file: /data/private_key
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-lldap"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/lldap/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/lldap/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/metube/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/metube/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-metube"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/metube/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/metube/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/pgadmin/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-pgadmin"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/pgadmin/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/plex/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/plex/app/helm-release.yaml
@@ -42,22 +42,6 @@ spec:
       disableGDM: true
       requireHTTPS: true # First Deploy set to false, till remote acces is configured and working
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-plex"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     service:
       main:
         type: LoadBalancer

--- a/clusters/main/kubernetes/apps/plex/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/plex/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/prowlarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-prowlarr"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/prowlarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/radarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/radarr/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-radarr"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/radarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/radarr/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/romm/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/romm/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-romm"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     securityContext:
       container:
         readOnlyRootFilesystem: true

--- a/clusters/main/kubernetes/apps/romm/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/romm/app/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials
 resources:
   - namespace.yaml
   - helm-release.yaml

--- a/clusters/main/kubernetes/apps/sabnzbd/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/app/helm-release.yaml
@@ -43,22 +43,6 @@ spec:
               env:
                 ENABLE_ADDITIONAL_METRICS: true
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-sabnzbd"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/sabnzbd/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/app/helm-release.yaml
@@ -59,22 +59,6 @@ spec:
               env:
                 AUTO_RECEIVE_SCHEDULE: 0 4 * * *
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-signal-cli"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials

--- a/clusters/main/kubernetes/apps/sonarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/app/helm-release.yaml
@@ -32,22 +32,6 @@ spec:
   values:
     TZ: Europe/Amsterdam
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-sonarr"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/sonarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/app/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials
 resources:
   - namespace.yaml
   - helm-release.yaml

--- a/clusters/main/kubernetes/apps/zwave-js-ui/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/app/helm-release.yaml
@@ -35,22 +35,6 @@ spec:
     global:
       stopAll: false
 
-    credentials:
-      minio:
-        type: s3
-        url: "http://${S3_URL}"
-        bucket: "${S3_BUCKET}-zwave-js-ui"
-        accessKey: "${S3_ACCESKEY}"
-        secretKey: "${S3_SECRETKEY}"
-        encrKey: "${S3_ENCRKEY}"
-      blaze:
-        type: s3
-        url: "https://${S3_BLAZE_URL}"
-        bucket: "${S3_BLAZE_BUCKET}"
-        accessKey: "${S3_BLAZE_ACCESKEY}"
-        secretKey: "${S3_BLAZE_SECRETKEY}"
-        encrKey: "${S3_BLAZE_ENCRKEY}"
-
     ingress:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/zwave-js-ui/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
 components:
   - ../../../../components/notifications/discord
+  - ../../../../components/backup/credentials


### PR DESCRIPTION
## Summary

- Migrate the remaining 17 applications to the shared backup-credentials Kustomize component.
- Remove the duplicated inline credentials blocks from their HelmReleases.
- Keep bucket names derived from each HelmRelease name; shared MinIO and Blaze configuration remains centralized.

## Validation

- Ran `kubectl kustomize` for all 17 affected application overlays.
- Verified each rendered MinIO bucket resolves to `${S3_BUCKET}-<application>`.
- No changes were applied to the cluster.