### PR TITLE
chore(yaml): add schema directives and document markers

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,3 +1,4 @@
+---
 name: Automerge and Approve
 
 on:

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -1,3 +1,4 @@
+---
 name: "Pull Request: Validate"
 
 on:

--- a/.github/workflows/testdeployment.yaml
+++ b/.github/workflows/testdeployment.yaml
@@ -1,3 +1,4 @@
+---
 name: HelmRelease test deployment
 
 on:

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,3 +1,4 @@
+---
 ## Do not edit between this and DO NOT REMOVE
 creation_rules:
   - path_regex: ^clusters.*kubernetes.values.ya?ml$

--- a/ci/.config.yaml
+++ b/ci/.config.yaml
@@ -1,3 +1,4 @@
+---
 # CI test configuration.
 # dummyEnv: Placeholder environment variables for Helm templating.
 # skipList: HelmRelease paths excluded from CI deployment tests.

--- a/ci/konflate.yaml
+++ b/ci/konflate.yaml
@@ -1,3 +1,4 @@
+---
 config:  
   statusChecks: false
   prComments: false

--- a/ci/minecraft-java.yaml
+++ b/ci/minecraft-java.yaml
@@ -1,3 +1,4 @@
+---
 workload:
     main:
         podSpec:

--- a/ci/plex.yaml
+++ b/ci/plex.yaml
@@ -1,2 +1,3 @@
+---
 plex:
     requireHTTPS: false

--- a/clusters/main/clusterenv.yaml
+++ b/clusters/main/clusterenv.yaml
@@ -1,3 +1,4 @@
+---
 #ENC[AES256_GCM,data:a112o9ORB17pCZi/ge2RmvmYOWh5Rjp9pUA35Q4FCrHmA2ZvnBziV2M5iXpmA7jjX/bUMiB/Km954nuMsl+TTcQ=,iv:5uJfyDeDhGPBV/GVf+28QUpDekF1iEwfXbO0oq4N+R0=,tag:BFPZSTVT6BSol+mjQGgEcg==,type:comment]
 #ENC[AES256_GCM,data:IyqwYtwNovA/kmTUKsPCLVyadfrmP6myO6+8DCYLtWqNqB/Dk4uPNOokOsQ=,iv:fN7ALC7UV3sgQPXk5NeyKA4TlZ9//4IfOIJZ/v5uuxA=,tag:y/xGCen35cYfaZp7ms5R6g==,type:comment]
 VIP: ENC[AES256_GCM,data:PtGGtqRIr4S5UMLEvw==,iv:CIh6xSsSc9mW0m6nWMs/C5Ee018FLnSlXm3m+ZI4wDQ=,tag:rExJ2fnm5hfj0vr2deExPg==,type:str]

--- a/clusters/main/components/backup/credentials/kustomization.yaml
+++ b/clusters/main/components/backup/credentials/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 

--- a/clusters/main/components/backup/credentials/patch.yaml
+++ b/clusters/main/components/backup/credentials/patch.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/components/gates/ingress-internal/kustomization.yaml
+++ b/clusters/main/components/gates/ingress-internal/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 patches:

--- a/clusters/main/components/gates/ingress-internal/patch.yaml
+++ b/clusters/main/components/gates/ingress-internal/patch.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/components/notifications/discord/kustomization.yaml
+++ b/clusters/main/components/notifications/discord/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/clusters/main/kubernetes/ai/codex/app/clusterrolebinding.yaml
+++ b/clusters/main/kubernetes/ai/codex/app/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/clusterrolebinding_v1.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/clusters/main/kubernetes/ai/codex/app/kustomization.yaml
+++ b/clusters/main/kubernetes/ai/codex/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/ai/codex/app/namespace.yaml
+++ b/clusters/main/kubernetes/ai/codex/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/ai/codex/app/rbac.yaml
+++ b/clusters/main/kubernetes/ai/codex/app/rbac.yaml
@@ -1,3 +1,4 @@
+---
 # Read-only CloudNativePG visibility across all namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/clusters/main/kubernetes/ai/codex/app/serviceaccount.yaml
+++ b/clusters/main/kubernetes/ai/codex/app/serviceaccount.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/serviceaccount_v1.json
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/clusters/main/kubernetes/ai/codex/ks.yaml
+++ b/clusters/main/kubernetes/ai/codex/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/ai/kustomization.yaml
+++ b/clusters/main/kubernetes/ai/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/boemel-runner.secret.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/boemel-runner.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/ks.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/boemel-runner/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/test-runner.secret.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/test-runner/app/test-runner.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/apps/actions-runner-system/test-runner/ks.yaml
+++ b/clusters/main/kubernetes/apps/actions-runner-system/test-runner/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/app/authelia-configfile.configmap.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/authelia-configfile.configmap.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/configmap_v1.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/app/authelia-oidc.secret.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/authelia-oidc.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/authelia/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/app/referencegrant.yaml
+++ b/clusters/main/kubernetes/apps/authelia/app/referencegrant.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/referencegrant_v1beta1.json
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/clusters/main/kubernetes/apps/authelia/ks.yaml
+++ b/clusters/main/kubernetes/apps/authelia/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/bazarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/bazarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/bazarr/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/bazarr/ks.yaml
+++ b/clusters/main/kubernetes/apps/bazarr/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/guacamole/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/guacamole/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/guacamole/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/guacamole/ks.yaml
+++ b/clusters/main/kubernetes/apps/guacamole/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/hermitcraft-java/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/hermitcraft-java/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/hermitcraft-java/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/hermitcraft-java/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/hermitcraft-java/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/hermitcraft-java/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/hermitcraft-java/ks.yaml
+++ b/clusters/main/kubernetes/apps/hermitcraft-java/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/home-assistant/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/home-assistant/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/home-assistant/ks.yaml
+++ b/clusters/main/kubernetes/apps/home-assistant/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/homepage/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/homepage/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/homepage/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/homepage/ks.yaml
+++ b/clusters/main/kubernetes/apps/homepage/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/immich/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/immich/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/immich/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/immich/ks.yaml
+++ b/clusters/main/kubernetes/apps/immich/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/it-tools/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/it-tools/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/it-tools/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/it-tools/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/it-tools/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/it-tools/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/it-tools/ks.yaml
+++ b/clusters/main/kubernetes/apps/it-tools/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/ks.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/librespeed/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/librespeed/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/librespeed/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/librespeed/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/librespeed/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/librespeed/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/librespeed/app/security_policy.yaml
+++ b/clusters/main/kubernetes/apps/librespeed/app/security_policy.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:

--- a/clusters/main/kubernetes/apps/librespeed/ks.yaml
+++ b/clusters/main/kubernetes/apps/librespeed/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/lldap/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/lldap/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/lldap/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/lldap/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/lldap/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/lldap/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/lldap/ks.yaml
+++ b/clusters/main/kubernetes/apps/lldap/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/metube/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/metube/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/metube/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/metube/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/metube/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/metube/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/metube/ks.yaml
+++ b/clusters/main/kubernetes/apps/metube/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-java/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-java/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-java/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-java/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/minecraft-java/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-java/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-java/ks.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-java/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-router/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-router/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-router/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-router/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/minecraft-router/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-router/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-router/ks.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-router/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-stats/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-stats/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-stats/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-stats/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/minecraft-stats/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-stats/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/minecraft-stats/ks.yaml
+++ b/clusters/main/kubernetes/apps/minecraft-stats/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/pgadmin/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/pgadmin/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/pgadmin/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/pgadmin/ks.yaml
+++ b/clusters/main/kubernetes/apps/pgadmin/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/plex/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/plex/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/plex/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/plex/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/plex/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/plex/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/plex/ks.yaml
+++ b/clusters/main/kubernetes/apps/plex/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/prowlarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/prowlarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/prowlarr/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/prowlarr/ks.yaml
+++ b/clusters/main/kubernetes/apps/prowlarr/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/radarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/radarr/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/radarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/radarr/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/radarr/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/radarr/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/radarr/ks.yaml
+++ b/clusters/main/kubernetes/apps/radarr/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/romm/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/romm/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/romm/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/romm/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/apps/romm/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/romm/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/romm/ks.yaml
+++ b/clusters/main/kubernetes/apps/romm/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/sabnzbd/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/sabnzbd/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/sabnzbd/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/sabnzbd/ks.yaml
+++ b/clusters/main/kubernetes/apps/sabnzbd/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/signal-cli-rest-api/ks.yaml
+++ b/clusters/main/kubernetes/apps/signal-cli-rest-api/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/sonarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/sonarr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/apps/sonarr/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/sonarr/ks.yaml
+++ b/clusters/main/kubernetes/apps/sonarr/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/speedtest-tracker/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/speedtest-tracker/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/speedtest-tracker/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/speedtest-tracker/ks.yaml
+++ b/clusters/main/kubernetes/apps/speedtest-tracker/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/webserver-dynmap/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/webserver-dynmap/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/webserver-dynmap/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/webserver-dynmap/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/webserver-dynmap/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/webserver-dynmap/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/webserver-dynmap/ks.yaml
+++ b/clusters/main/kubernetes/apps/webserver-dynmap/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/apps/zwave-js-ui/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/apps/zwave-js-ui/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/apps/zwave-js-ui/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/apps/zwave-js-ui/ks.yaml
+++ b/clusters/main/kubernetes/apps/zwave-js-ui/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/core/blocky/app/kustomization.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/core/blocky/app/namespace.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/core/blocky/ks.yaml
+++ b/clusters/main/kubernetes/core/blocky/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/core/clusterissuer/app/kustomization.yaml
+++ b/clusters/main/kubernetes/core/clusterissuer/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/core/clusterissuer/app/namespace.yaml
+++ b/clusters/main/kubernetes/core/clusterissuer/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/core/clusterissuer/ks.yaml
+++ b/clusters/main/kubernetes/core/clusterissuer/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/core/kustomization.yaml
+++ b/clusters/main/kubernetes/core/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/core/metallb-config/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/metallb-config/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/core/metallb-config/app/kustomization.yaml
+++ b/clusters/main/kubernetes/core/metallb-config/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/core/metallb-config/app/namespace.yaml
+++ b/clusters/main/kubernetes/core/metallb-config/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/core/metallb-config/ks.yaml
+++ b/clusters/main/kubernetes/core/metallb-config/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-denon/app/helm-release.yaml
+++ b/clusters/main/kubernetes/external-services/ext-denon/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-denon/app/kustomization.yaml
+++ b/clusters/main/kubernetes/external-services/ext-denon/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/external-services/ext-denon/ks.yaml
+++ b/clusters/main/kubernetes/external-services/ext-denon/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-plugwise/app/helm-release.yaml
+++ b/clusters/main/kubernetes/external-services/ext-plugwise/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-plugwise/app/kustomization.yaml
+++ b/clusters/main/kubernetes/external-services/ext-plugwise/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/external-services/ext-plugwise/ks.yaml
+++ b/clusters/main/kubernetes/external-services/ext-plugwise/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-truenas/app/helm-release.yaml
+++ b/clusters/main/kubernetes/external-services/ext-truenas/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-truenas/app/kustomization.yaml
+++ b/clusters/main/kubernetes/external-services/ext-truenas/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/external-services/ext-truenas/ks.yaml
+++ b/clusters/main/kubernetes/external-services/ext-truenas/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-unifi/app/helm-release.yaml
+++ b/clusters/main/kubernetes/external-services/ext-unifi/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/external-services/ext-unifi/app/kustomization.yaml
+++ b/clusters/main/kubernetes/external-services/ext-unifi/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/external-services/ext-unifi/ks.yaml
+++ b/clusters/main/kubernetes/external-services/ext-unifi/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/external-services/kustomization.yaml
+++ b/clusters/main/kubernetes/external-services/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/external-services/namespace.yaml
+++ b/clusters/main/kubernetes/external-services/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/flux-system/flux-instance/app/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/flux-instance/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/flux-system/flux-operator/app/clusterrolebinding.yaml
+++ b/clusters/main/kubernetes/flux-system/flux-operator/app/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/clusterrolebinding_v1.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/clusters/main/kubernetes/flux-system/flux-operator/app/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/flux-operator/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/configmap_v1.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/clusters/main/kubernetes/flux-system/flux/deploykey.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/deploykey.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/flux-system/flux/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/flux-system/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system

--- a/clusters/main/kubernetes/flux-system/namespace.yaml
+++ b/clusters/main/kubernetes/flux-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/flux-system/webhooks/github/ingress.yaml
+++ b/clusters/main/kubernetes/flux-system/webhooks/github/ingress.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/ingress_v1.json
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/clusters/main/kubernetes/flux-system/webhooks/github/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/webhooks/github/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/flux-system/webhooks/github/receiver.yaml
+++ b/clusters/main/kubernetes/flux-system/webhooks/github/receiver.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/notification.toolkit.fluxcd.io/receiver_v1.json
 apiVersion: notification.toolkit.fluxcd.io/v1
 kind: Receiver
 metadata:

--- a/clusters/main/kubernetes/flux-system/webhooks/github/webhook.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/webhooks/github/webhook.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/flux-system/webhooks/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/webhooks/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/cilium/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/cilium/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/kube-system/cilium/app/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/cilium/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/cilium/ks.yaml
+++ b/clusters/main/kubernetes/kube-system/cilium/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/descheduler/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/kube-system/descheduler/app/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/descheduler/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/descheduler/ks.yaml
+++ b/clusters/main/kubernetes/kube-system/descheduler/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/kube-system/kubelet-csr-approver/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/kubelet-csr-approver/app/helm-release.yaml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/clusters/main/kubernetes/kube-system/kubelet-csr-approver/app/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/kubelet-csr-approver/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/kubelet-csr-approver/ks.yaml
+++ b/clusters/main/kubernetes/kube-system/kubelet-csr-approver/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/kube-system/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/metrics-server/app/helm-release.yaml
+++ b/clusters/main/kubernetes/kube-system/metrics-server/app/helm-release.yaml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/clusters/main/kubernetes/kube-system/metrics-server/app/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/metrics-server/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/metrics-server/ks.yaml
+++ b/clusters/main/kubernetes/kube-system/metrics-server/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/kube-system/namespace.yaml
+++ b/clusters/main/kubernetes/kube-system/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/kube-system/node-feature-discovery/app/kustomization.yaml
+++ b/clusters/main/kubernetes/kube-system/node-feature-discovery/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/kube-system/node-feature-discovery/ks.yaml
+++ b/clusters/main/kubernetes/kube-system/node-feature-discovery/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/kustomization.yaml
+++ b/clusters/main/kubernetes/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/networking/cloudflared/app/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/cloudflared/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/networking/cloudflared/app/namespace.yaml
+++ b/clusters/main/kubernetes/networking/cloudflared/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/networking/cloudflared/ks.yaml
+++ b/clusters/main/kubernetes/networking/cloudflared/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/networking/cloudflareddns/app/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/cloudflareddns/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/networking/cloudflareddns/app/namespace.yaml
+++ b/clusters/main/kubernetes/networking/cloudflareddns/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/networking/cloudflareddns/ks.yaml
+++ b/clusters/main/kubernetes/networking/cloudflareddns/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/networking/envoy-gateway/app/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/envoy-gateway/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/networking/envoy-gateway/app/namespace.yaml
+++ b/clusters/main/kubernetes/networking/envoy-gateway/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/networking/envoy-gateway/app/podmonitor.yaml
+++ b/clusters/main/kubernetes/networking/envoy-gateway/app/podmonitor.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/clusters/main/kubernetes/networking/envoy-gateway/ks.yaml
+++ b/clusters/main/kubernetes/networking/envoy-gateway/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/networking/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/networking/nginx-external/app/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/nginx-external/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/networking/nginx-external/app/namespace.yaml
+++ b/clusters/main/kubernetes/networking/nginx-external/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/networking/nginx-external/ks.yaml
+++ b/clusters/main/kubernetes/networking/nginx-external/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/networking/nginx-internal/app/kustomization.yaml
+++ b/clusters/main/kubernetes/networking/nginx-internal/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/networking/nginx-internal/app/namespace.yaml
+++ b/clusters/main/kubernetes/networking/nginx-internal/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/networking/nginx-internal/ks.yaml
+++ b/clusters/main/kubernetes/networking/nginx-internal/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/gatus/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/gatus/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/gatus/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/gatus/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/gatus/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/gatus/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/gatus/ks.yaml
+++ b/clusters/main/kubernetes/observability/gatus/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-alloy/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/grafana-alloy/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-alloy/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/grafana-alloy/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/grafana-alloy/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/grafana-alloy/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-alloy/ks.yaml
+++ b/clusters/main/kubernetes/observability/grafana-alloy/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-loki/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/grafana-loki/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-loki/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/grafana-loki/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/observability/grafana-loki/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/grafana-loki/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-loki/ks.yaml
+++ b/clusters/main/kubernetes/observability/grafana-loki/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-operator/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/grafana-operator/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-operator/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/grafana-operator/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/grafana-operator/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/grafana-operator/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-operator/instance/credentials.secret.yaml
+++ b/clusters/main/kubernetes/observability/grafana-operator/instance/credentials.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/observability/grafana-operator/instance/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/grafana-operator/instance/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/headlamp/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/headlamp/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/headlamp/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/headlamp/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/headlamp/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/headlamp/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/headlamp/ks.yaml
+++ b/clusters/main/kubernetes/observability/headlamp/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/ipmi-exporter/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/ipmi-exporter/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/observability/ipmi-exporter/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/ipmi-exporter/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/ipmi-exporter/ks.yaml
+++ b/clusters/main/kubernetes/observability/ipmi-exporter/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/konflate/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/konflate/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/konflate/app/konflate.secret.yaml
+++ b/clusters/main/kubernetes/observability/konflate/app/konflate.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/observability/konflate/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/konflate/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/konflate/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/konflate/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/konflate/ks.yaml
+++ b/clusters/main/kubernetes/observability/konflate/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/kromgo/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/kromgo/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/kromgo/ks.yaml
+++ b/clusters/main/kubernetes/observability/kromgo/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/alertmanager.secret.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/alertmanager.secret.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/secret_v1.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/app/promethuesrule.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/app/promethuesrule.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/clusters/main/kubernetes/observability/kube-prometheus-stack/ks.yaml
+++ b/clusters/main/kubernetes/observability/kube-prometheus-stack/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/shelly-exporter/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/shelly-exporter/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/shelly-exporter/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/shelly-exporter/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/shelly-exporter/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/shelly-exporter/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/shelly-exporter/ks.yaml
+++ b/clusters/main/kubernetes/observability/shelly-exporter/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/smartctl-exporter/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/smartctl-exporter/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/observability/smartctl-exporter/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/smartctl-exporter/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/smartctl-exporter/ks.yaml
+++ b/clusters/main/kubernetes/observability/smartctl-exporter/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/truenas-exporter/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/truenas-exporter/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/truenas-exporter/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/truenas-exporter/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/observability/truenas-exporter/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/truenas-exporter/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/truenas-exporter/ks.yaml
+++ b/clusters/main/kubernetes/observability/truenas-exporter/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/observability/unpoller/app/helm-release.yaml
+++ b/clusters/main/kubernetes/observability/unpoller/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/observability/unpoller/app/kustomization.yaml
+++ b/clusters/main/kubernetes/observability/unpoller/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/observability/unpoller/app/namespace.yaml
+++ b/clusters/main/kubernetes/observability/unpoller/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/observability/unpoller/ks.yaml
+++ b/clusters/main/kubernetes/observability/unpoller/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/cert-manager/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/cert-manager/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/cert-manager/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/cert-manager/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/cert-manager/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/cert-manager/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/cert-manager/ks.yaml
+++ b/clusters/main/kubernetes/system/cert-manager/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/cloudnative-pg/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/cloudnative-pg/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/cloudnative-pg/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/cloudnative-pg/ks.yaml
+++ b/clusters/main/kubernetes/system/cloudnative-pg/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/kubernetes-reflector/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/kubernetes-reflector/app/helm-release.yaml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/clusters/main/kubernetes/system/kubernetes-reflector/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/kubernetes-reflector/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/kubernetes-reflector/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/kubernetes-reflector/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/kubernetes-reflector/ks.yaml
+++ b/clusters/main/kubernetes/system/kubernetes-reflector/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/kustomization.yaml
+++ b/clusters/main/kubernetes/system/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/app/ingress.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/ingress.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/ingress_v1.json
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/longhorn/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/app/networkpolicy.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/networkpolicy.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/networking.k8s.io/networkpolicy_v1.json
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/app/trim.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/trim.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/longhorn.io/recurringjob_v1beta2.json
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/app/volumeSnapshotClass.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/volumeSnapshotClass.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/snapshot.storage.k8s.io/volumesnapshotclass_v1.json
 kind: VolumeSnapshotClass
 apiVersion: snapshot.storage.k8s.io/v1
 metadata:

--- a/clusters/main/kubernetes/system/longhorn/ks.yaml
+++ b/clusters/main/kubernetes/system/longhorn/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/metallb/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/metallb/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/metallb/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/metallb/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/metallb/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/metallb/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/metallb/ks.yaml
+++ b/clusters/main/kubernetes/system/metallb/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/openebs/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/openebs/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/openebs/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/openebs/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/openebs/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/openebs/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/openebs/ks.yaml
+++ b/clusters/main/kubernetes/system/openebs/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/renovate/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/renovate/app/helm-release.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/renovate/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/renovate/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/renovate/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/renovate/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/renovate/ks.yaml
+++ b/clusters/main/kubernetes/system/renovate/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/snapshot-controller/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/snapshot-controller/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/snapshot-controller/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/snapshot-controller/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/snapshot-controller/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/snapshot-controller/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/snapshot-controller/ks.yaml
+++ b/clusters/main/kubernetes/system/snapshot-controller/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/kustomization.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/system-upgrade/namespace.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/kubernetes.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/kubernetes.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
 apiVersion: tuppr.home-operations.com/v1alpha1
 kind: KubernetesUpgrade
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/talos.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/app/talos.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/tuppr.home-operations.com/talosupgrade_v1alpha1.json
 apiVersion: tuppr.home-operations.com/v1alpha1
 kind: TalosUpgrade
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/ks.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr-plans/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr/app/helm-release.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/system/system-upgrade/tuppr/ks.yaml
+++ b/clusters/main/kubernetes/system/system-upgrade/tuppr/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/system/volsync/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/volsync/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/system/volsync/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/volsync/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/clusters/main/kubernetes/system/volsync/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/volsync/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/system/volsync/ks.yaml
+++ b/clusters/main/kubernetes/system/volsync/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/tests/authentik/app/helm-release.yaml
+++ b/clusters/main/kubernetes/tests/authentik/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/tests/authentik/app/kustomization.yaml
+++ b/clusters/main/kubernetes/tests/authentik/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/tests/authentik/app/namespace.yaml
+++ b/clusters/main/kubernetes/tests/authentik/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/tests/authentik/ks.yaml
+++ b/clusters/main/kubernetes/tests/authentik/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/tests/deluge/app/helm-release.yaml
+++ b/clusters/main/kubernetes/tests/deluge/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/tests/deluge/app/kustomization.yaml
+++ b/clusters/main/kubernetes/tests/deluge/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/tests/deluge/app/namespace.yaml
+++ b/clusters/main/kubernetes/tests/deluge/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/tests/deluge/ks.yaml
+++ b/clusters/main/kubernetes/tests/deluge/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/tests/kustomization.yaml
+++ b/clusters/main/kubernetes/tests/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/tests/tandoor/app/helm-release.yaml
+++ b/clusters/main/kubernetes/tests/tandoor/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/tests/tandoor/app/kustomization.yaml
+++ b/clusters/main/kubernetes/tests/tandoor/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/tests/tandoor/app/namespace.yaml
+++ b/clusters/main/kubernetes/tests/tandoor/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/tests/tandoor/ks.yaml
+++ b/clusters/main/kubernetes/tests/tandoor/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/kubernetes/tests/wg-easy/app/helm-release.yaml
+++ b/clusters/main/kubernetes/tests/wg-easy/app/helm-release.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/clusters/main/kubernetes/tests/wg-easy/app/kustomization.yaml
+++ b/clusters/main/kubernetes/tests/wg-easy/app/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/clusters/main/kubernetes/tests/wg-easy/app/namespace.yaml
+++ b/clusters/main/kubernetes/tests/wg-easy/app/namespace.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/namespace_v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/clusters/main/kubernetes/tests/wg-easy/ks.yaml
+++ b/clusters/main/kubernetes/tests/wg-easy/ks.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/clusters/main/talos/generated/talsecret.yaml
+++ b/clusters/main/talos/generated/talsecret.yaml
@@ -1,3 +1,4 @@
+---
 cluster:
     id: ENC[AES256_GCM,data:iCuTPgB3+UFrVcadqLZKFfZXcT2+LJK1ATRe1QgRnFZgPj5GAR2oXGsFjj8=,iv:uK21uUD8Vq2OMTVpzodJaMR3tWEQH5W1TUhRz1AsMO0=,tag:PCUZxfW+oFpR/+DH1h4rSg==,type:str]
     secret: ENC[AES256_GCM,data:/HksQir4mL1KTtiZWvlChkD/5iHHV11firHnJEh+l5JuVjvqSpS4yCjp77k=,iv:qZ0LfB+b7OGIFhKCV7VckshYV5CRd4x61s6Z2rj95NU=,tag:wt9RBu2pdGL5CvJ3GuAUxA==,type:str]

--- a/clusters/main/talos/patches/all.yaml
+++ b/clusters/main/talos/patches/all.yaml
@@ -1,3 +1,4 @@
+---
 cluster:
   proxy:
     disabled: true

--- a/clusters/main/talos/patches/controlplane.yaml
+++ b/clusters/main/talos/patches/controlplane.yaml
@@ -1,3 +1,4 @@
+---
 machine:
   features:
     kubernetesTalosAPIAccess:

--- a/clusters/main/talos/patches/garbagecollection.yaml
+++ b/clusters/main/talos/patches/garbagecollection.yaml
@@ -1,3 +1,4 @@
+---
 machine:
   kubelet:
     extraConfig:

--- a/clusters/main/talos/patches/worker.yaml
+++ b/clusters/main/talos/patches/worker.yaml
@@ -1,3 +1,4 @@
+---
 machine:
   time:
     disabled: false

--- a/clusters/main/talos/talconfig.yaml
+++ b/clusters/main/talos/talconfig.yaml
@@ -1,3 +1,4 @@
+---
 clusterName: ${CLUSTERNAME}
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.9

--- a/repositories/git/kustomization.yaml
+++ b/repositories/git/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/repositories/helm/kustomization.yaml
+++ b/repositories/helm/kustomization.yaml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 metadata:

--- a/repositories/kustomization.yaml
+++ b/repositories/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/repositories/oci/kustomization.yaml
+++ b/repositories/oci/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
## Summary

- add `---` document start markers to all YAML files
- add resource-specific schemas from `k8s-schemas.home-operations.com` when available
- replace existing SchemaStore Kustomize associations with the matching Home Operations schemas

Five mixed-kind multi-document manifests intentionally do not receive a resource-specific schema directive because a YAML Language Server modeline applies to the whole file.

## Validation

- confirmed 425/425 YAML files start with `---`
- confirmed 397/397 homogeneous Kubernetes manifests have a schema directive
- verified every Home Operations schema URL against the current schema index
- confirmed only document markers and schema comments changed
- `git diff --check`
- `kubectl kustomize clusters/main/kubernetes`