### PR TITLE
chore(ci): manage HelmRelease test tools with mise

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -12,7 +12,9 @@
         "!/flux-operator/",
         "!/flux-instance/",        
         "!/longhorn/",
-        "!/cilium/"
+        "!/cilium/",
+        "!/k3s-io/",
+        "!/k3d-io/"
       ],
       automerge: true,
       addLabels: ["automerge"]  
@@ -22,7 +24,9 @@
       matchPackageNames: [
         "!/siderolabs/",
         "!/flux-operator/",
-        "!/flux-instance/"           
+        "!/flux-instance/",
+        "!/k3s-io/",
+        "!/k3d-io/"
       ],
       automerge: true,
       addLabels: ["automerge"]

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -44,6 +44,9 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
+          install_args: >-
+            kubeconform
+            kustomize
       - name: Run kubeconform
         shell: bash
         run: bash ./.github/scripts/kubeconform.sh ${{ env.KUBERNETES_DIR }}

--- a/.github/workflows/testdeployment.yaml
+++ b/.github/workflows/testdeployment.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect:
     runs-on: ubuntu-latest
@@ -20,6 +23,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+          install_args: >-
+            jq
+            yq
 
       - name: Detect changed HelmReleases
         id: set
@@ -167,17 +179,21 @@ jobs:
       # --------------------------------------------------
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # --------------------------------------------------
-      # Install required CLI tools
+      # Setup required CLI tools
       # --------------------------------------------------
-      - name: Install tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq gettext
-          sudo curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
-            -o /usr/local/bin/yq
-          sudo chmod +x /usr/local/bin/yq
+      - name: Setup Mise
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+          install_args: >-
+            helm
+            jq
+            kubectl
+            yq
 
       # --------------------------------------------------
       # Dummy env vars for Helm interpolation
@@ -189,28 +205,18 @@ jobs:
       # --------------------------------------------------
       # Create ephemeral k3d cluster
       # --------------------------------------------------
-      - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
-
-      - name: Install helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        with:
-          version: v4.2.4
-
       - name: Create k3d cluster
         timeout-minutes: 2
         uses: nolar/setup-k3d-k3s@62c9d1bd2bc843275c85d2e7dcd696edc1160eee # v1.1.0
         with:
+          # renovate: datasource=github-releases depName=k3s-io/k3s
           version: v1.36.1+k3s1
+          # renovate: datasource=github-releases depName=k3d-io/k3d
+          k3d-tag: v5.9.0
+          github-token: ${{ github.token }}
           k3d-args: >-
             --k3s-arg --disable=metrics-server@server:*
             --k3s-arg --disable=traefik@server:*
-          # github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Remove node taints
-        run: |
-          kubectl taint --all=true nodes node.cloudprovider.kubernetes.io/uninitialized- || true
-
       # --------------------------------------------------
       # Deploy & test HelmRelease
       # --------------------------------------------------

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,8 @@
 [tools]
 flux2 = "2.9.4"
+helm = "4.2.4"
+jq = "1.8.2"
 kubeconform = "0.8.0"
+kubectl = "1.36.1"
 kustomize = "5.8.1"
+yq = "4.53.3"


### PR DESCRIPTION
## Summary

- manage Helm, jq, kubectl, and yq versions centrally in `.mise.toml`
- install only the tools needed by each HelmRelease test job with `install_args`
- use the runner-provided `envsubst` instead of running a redundant apt installation
- pin both the k3s cluster version and the k3d CLI version
- let Renovate detect k3s and k3d releases, without automerging their minor or patch updates
- restrict the existing kubeconform job to its own required mise tools
- reduce workflow permissions and avoid persisting checkout credentials
- authenticate k3d setup downloads with the temporary read-only GitHub token
- remove the obsolete cloud-provider taint command from the k3d job

## Tool versions

- Helm: `4.2.4`
- jq: `1.8.2`
- kubectl: `1.36.1`
- yq: `4.53.3`
- k3s: `v1.36.1+k3s1`
- k3d: `v5.9.0`

## Security and reliability

- workflow-level permissions are limited to `contents: read`
- checkout credentials are not persisted after checkout
- the k3d action receives the job-scoped `github.token` to avoid unauthenticated API rate limits
- GitHub Actions remain pinned to full commit SHAs
- k3s and k3d Renovate PRs require manual review, including patch updates
- the GitHub-hosted runner provides job-level cleanup for the disposable k3d cluster

## Validation

- `git diff --check`
- completed a successful end-to-end speedtest-tracker HelmRelease deployment
- verified mise installed the temporary yq `4.53.2` version directly from `.mise.toml`
- verified the runner-provided `envsubst` works without package installation
- verified k3d `v5.9.0` and k3s `v1.36.1+k3s1` in the workflow logs
- restored yq to `4.53.3` and removed the temporary HelmRelease test note
- verified the existing annotated-dependency custom manager matches the k3s and k3d annotations

## Notes

- mise caching remains disabled
- HelmRelease detection and matrix behavior are unchanged
- dependency installation logic is unchanged
- this removes the unpinned `yq` latest download and the separate Helm/kubectl setup actions