### PR TITLE
test(ci): run HelmRelease canary for tooling changes

### DIFF
--- a/.github/workflows/testdeployment.yaml
+++ b/.github/workflows/testdeployment.yaml
@@ -64,9 +64,26 @@ jobs:
               --name-only)
           fi
 
+          tooling_changed=false
+
+          if printf '%s\n' "$changed_files" \
+            | grep -qxE '^(\.mise\.toml|ci/\.config\.yaml|\.github/workflows/testdeployment\.yaml|\.github/scripts/deploy_helmrelease\.sh)$'; then
+            tooling_changed=true
+            canary_helmrelease=$(yq -r '.canaryHelmRelease // ""' ci/.config.yaml)
+
+            if [ -z "$canary_helmrelease" ] || [ ! -f "$canary_helmrelease" ]; then
+              echo "❌ Canary HelmRelease not found: $canary_helmrelease"
+              exit 1
+            fi
+          fi
+
           files="$({
             printf '%s\n' "$changed_files" \
               | grep 'helm-release.yaml$' || true
+
+            if $tooling_changed; then
+              echo "$canary_helmrelease"
+            fi
 
             while IFS= read -r source_file; do
               [ -f "$source_file" ] || continue
@@ -245,7 +262,6 @@ jobs:
       # --------------------------------------------------
       - name: Test HelmRelease
         run: |
-          chmod +x .github/scripts/deploy_helmrelease.sh
           bash .github/scripts/deploy_helmrelease.sh "${{ matrix.helmrelease }}"
 
   test-summary:

--- a/ci/.config.yaml
+++ b/ci/.config.yaml
@@ -1,7 +1,10 @@
 ---
 # CI test configuration.
 # dummyEnv: Placeholder environment variables for Helm templating.
+# canaryHelmRelease: HelmRelease tested when CI tooling changes.
 # skipList: HelmRelease paths excluded from CI deployment tests.
+
+canaryHelmRelease: clusters/main/kubernetes/apps/speedtest-tracker/app/helm-release.yaml
 
 dummyEnv:
   BASE_DOMAIN: base.dummy.local


### PR DESCRIPTION
## Summary

- configure speedtest-tracker as the HelmRelease canary in `ci/.config.yaml`
- automatically add that canary to the existing matrix when `.mise.toml`, `ci/.config.yaml`, the HelmRelease test workflow, or its deployment script changes
- validate that the configured canary path exists before constructing the matrix
- keep normal HelmRelease and OCIRepository detection, matrix behavior, and skip-list handling unchanged
- remove the unnecessary `chmod +x` before invoking the deployment script with `bash`

## Testing

- rebased the branch onto the current `main`, including manual `workflow_dispatch` support
- verified the final comparison contains only `.github/workflows/testdeployment.yaml` and `ci/.config.yaml`
- this PR changes both the workflow and CI config, so its own check must select and deploy the configured canary