### PR TITLE
chore(ci): pin mise runtime in HelmRelease test

### DIFF
--- a/.github/workflows/helmrelease-test.yaml
+++ b/.github/workflows/helmrelease-test.yaml
@@ -17,6 +17,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=jdx/mise
+  MISE_VERSION: 2026.8.12
+
 jobs:
   detect:
     runs-on: ubuntu-latest
@@ -33,6 +37,7 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
+          version: ${{ env.MISE_VERSION }}
           cache: false
           install_args: >-
             jq
@@ -228,6 +233,7 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
+          version: ${{ env.MISE_VERSION }}
           cache: false
           install_args: >-
             helm


### PR DESCRIPTION
## Summary

- pin the mise runtime used by `.github/workflows/helmrelease-test.yaml` to `2026.8.12`
- define the version once as `MISE_VERSION` and use it in both `Setup Mise` steps
- annotate the version for Renovate using the `jdx/mise` GitHub releases datasource

## Action audit scope

Only actions used by the HelmRelease test workflow were reviewed:

- `actions/checkout` is pinned by commit SHA and has no separate downloaded tool version input
- `jdx/mise-action` is pinned by commit SHA; this PR additionally pins the mise binary it installs
- `nolar/setup-k3d-k3s` is pinned by commit SHA and already receives exact k3s and k3d versions

## Verification

- the final diff changes only `.github/workflows/helmrelease-test.yaml`
- the workflow change itself triggers the configured HelmRelease canary
- the existing Renovate regex manager recognizes the adjacent `jdx/mise` annotation and `MISE_VERSION` value