### PR TITLE
fix(ci): modernize automerge app token

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -23,8 +23,11 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.BOEMEL_ACTIONS_APP_ID }}
-          private-key: ${{ secrets.BOEMEL_ACTIONS_APP_PRIVATE_KEY }}    
+          client-id: ${{ secrets.BOEMEL_ACTIONS_CLIENT_ID }}
+          private-key: ${{ secrets.BOEMEL_ACTIONS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write    
       - name: automerge
         uses: "pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67" # v0.16.4
         id: automerge


### PR DESCRIPTION
## Summary

- replace the deprecated `app-id` input with `client-id`
- use the existing `BOEMEL_ACTIONS_CLIENT_ID` secret
- explicitly restrict the temporary automerge token to:
  - repository contents: write
  - pull requests: write
  - workflow files: write

## Why

The GitHub App now has permission to update workflow files, which is required to merge Renovate pull requests that change `.github/workflows/*`. Explicit token permissions prevent this automerge run from inheriting unrelated permissions granted to the App.

## Scope

This PR changes only the active `.github/workflows/automerge.yaml` workflow. The unused `pr-validate.yaml` workflow remains untouched.